### PR TITLE
fix: branch main, COC v2.1, README headings, scope package name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    timeout-minutes: 6
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: [24.x, 22.x]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 ![Seneca](http://senecajs.org/files/assets/seneca-logo.png)
-
-> A [Seneca.js](https://www.npmjs.com/package/seneca) plugin for providing API keys.
+> A [Seneca.js](http://senecajs.org) plugin
 
 # @seneca/apikey
 
+[![npm version](https://img.shields.io/npm/v/@seneca/apikey.svg)](https://npmjs.com/package/@seneca/apikey)
+[![build](https://github.com/senecajs/seneca-apikey/actions/workflows/build.yml/badge.svg)](https://github.com/senecajs/seneca-apikey/actions/workflows/build.yml)
+[![Known Vulnerabilities](https://snyk.io/test/github/senecajs/seneca-apikey/badge.svg)](https://snyk.io/test/github/senecajs/seneca-apikey)
 [![npm version][npm-badge]][npm-url]
 [![Build Status][travis-badge]][travis-url]
 [![Coverage Status][coveralls-badge]][coveralls-url]
@@ -13,12 +15,7 @@
 [![Gitter][gitter-badge]][gitter-url]
 
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
-| ---------------------------------------------------- | --------------------------------------------------------------------------------------- |
-
-
-This module is a plugin for the [Seneca framework](http://senecajs.org). It provides common actions for supplying API keys to external clients.
-
-API keys are generated and hashed to the same level as passwords.
+|---|---|
 
 ## Install
 
@@ -136,11 +133,25 @@ Verify an API key.
 
 ## Motivation
 
+
+
 ## Support
+
+If you're using this module and need help, you can:
+
+- Post a [github issue](https://github.com/senecajs/seneca-apikey/issues)
+- Tweet to [@senecajs](http://twitter.com/senecajs)
+- Ask on the [Gitter](https://gitter.im/senecajs/seneca)
 
 ## API
 
+
+
 ## Contributing
+
+The [Senecajs org](https://github.com/senecajs/) encourages open participation. If you feel you can help in any way, be it with documentation, examples, extra testing, or new features please get in touch.
+
+
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,9 @@
 [![npm version](https://img.shields.io/npm/v/@seneca/apikey.svg)](https://npmjs.com/package/@seneca/apikey)
 [![build](https://github.com/senecajs/seneca-apikey/actions/workflows/build.yml/badge.svg)](https://github.com/senecajs/seneca-apikey/actions/workflows/build.yml)
 [![Known Vulnerabilities](https://snyk.io/test/github/senecajs/seneca-apikey/badge.svg)](https://snyk.io/test/github/senecajs/seneca-apikey)
-[![npm version][npm-badge]][npm-url]
-[![Build Status][travis-badge]][travis-url]
-[![Coverage Status][coveralls-badge]][coveralls-url]
-[![Maintainability][codeclimate-badge]][codeclimate-url]
+[![Coverage Status](https://coveralls.io/repos/github/senecajs/seneca-apikey/badge.svg?branch=master)](https://coveralls.io/github/senecajs/seneca-apikey?branch=master)
+[![Maintainability](https://api.codeclimate.com/v1/badges/79f285a2bfb61305af0f/maintainability)](https://codeclimate.com/github/senecajs/seneca-apikey/maintainability)
 [![DeepScan grade](https://deepscan.io/api/teams/5016/projects/11602/branches/173763/badge/grade.svg)](https://deepscan.io/dashboard#view=project&tid=5016&pid=11602&bid=173763)
-[![Dependency Status][david-badge]][david-url]
 
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
@@ -24,7 +21,7 @@ npm install seneca-promisify // dependency
 npm install seneca-entity // dependency
 npm install @seneca/user // dependency
 npm install @seneca/apikey
-```
+```js
 
 ## Quick Example
 
@@ -36,7 +33,7 @@ const Seneca = require('seneca')
 var seneca = Seneca().use('promisify').use('entity').use('apikey')
 
 // TODO: complete quick example
-```
+```js
 
 ## More Examples
 
@@ -65,7 +62,7 @@ Set plugin options when loading with:
 
 seneca.use('apikey', { name: value, ... })
 
-```
+```js
 
 <small>Note: <code>foo.bar</code> in the list above means
 <code>{ foo: { bar: ... } }</code></small>
@@ -96,12 +93,12 @@ Generate a new API key.
 
 ##### Replies With
 
-```
+```json
 {
   ok: '`true` if successful',
   key: 'key string'
 }
-```
+```js
 
 ---
 
@@ -117,12 +114,12 @@ Verify an API key.
 
 ##### Replies With
 
-```
+```json
 {
   ok: '`true` if verified',
   why: 'explanation code'
 }
-```
+```js
 
 ---
 
@@ -153,10 +150,4 @@ Licensed under [MIT][].
 
 [mit]: ./LICENSE
 [seneca.js]: https://www.npmjs.com/package/seneca
-[coveralls-badge]: https://coveralls.io/repos/github/senecajs/seneca-apikey/badge.svg?branch=master
-[coveralls-url]: https://coveralls.io/github/senecajs/seneca-apikey?branch=master
-[codeclimate-badge]: https://api.codeclimate.com/v1/badges/79f285a2bfb61305af0f/maintainability
-[codeclimate-url]: https://codeclimate.com/github/senecajs/seneca-apikey/maintainability
-[npm-badge]: https://img.shields.io/npm/v/@seneca/apikey.svg
-[npm-url]: https://npmjs.com/package/@seneca/apikey
 [senecajs org]: https://github.com/senecajs/

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Install
 
-```
+```sh
 npm install seneca
 npm install seneca-promisify // dependency
 npm install seneca-entity // dependency
@@ -26,7 +26,7 @@ npm install @seneca/apikey
 
 Register an apikey and then create an automatic login for testing.
 
-```
+```js
 const Seneca = require('seneca')
 
 var seneca = Seneca().use('promisify').use('entity').use('apikey')
@@ -56,7 +56,7 @@ detailed usage examples:
 
 Set plugin options when loading with:
 
-```
+```js
 seneca.use('apikey', { name: value, ... })
 
 ```
@@ -89,7 +89,7 @@ Generate a new API key.
 
 ##### Replies With
 
-```
+```json
 {
   ok: '`true` if successful',
   key: 'key string'
@@ -109,7 +109,7 @@ Verify an API key.
 
 ##### Replies With
 
-```
+```json
 {
   ok: '`true` if verified',
   why: 'explanation code'

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Generate a new API key.
 
 ##### Replies With
 
-```json
+```js
 {
   ok: '`true` if successful',
   key: 'key string'
@@ -109,7 +109,7 @@ Verify an API key.
 
 ##### Replies With
 
-```json
+```js
 {
   ok: '`true` if verified',
   why: 'explanation code'

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 [![Maintainability][codeclimate-badge]][codeclimate-url]
 [![DeepScan grade](https://deepscan.io/api/teams/5016/projects/11602/branches/173763/badge/grade.svg)](https://deepscan.io/dashboard#view=project&tid=5016&pid=11602&bid=173763)
 [![Dependency Status][david-badge]][david-url]
-[![Gitter][gitter-badge]][gitter-url]
 
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
@@ -64,9 +63,7 @@ Set plugin options when loading with:
 
 ```js
 
-
 seneca.use('apikey', { name: value, ... })
-
 
 ```
 
@@ -133,8 +130,6 @@ Verify an API key.
 
 ## Motivation
 
-
-
 ## Support
 
 If you're using this module and need help, you can:
@@ -145,13 +140,9 @@ If you're using this module and need help, you can:
 
 ## API
 
-
-
 ## Contributing
 
 The [Senecajs org](https://github.com/senecajs/) encourages open participation. If you feel you can help in any way, be it with documentation, examples, extra testing, or new features please get in touch.
-
-
 
 ## Background
 
@@ -162,16 +153,10 @@ Licensed under [MIT][].
 
 [mit]: ./LICENSE
 [seneca.js]: https://www.npmjs.com/package/seneca
-[travis-badge]: https://travis-ci.com/senecajs/seneca-apikey.svg?branch=master
-[travis-url]: https://travis-ci.com/senecajs/seneca-apikey
 [coveralls-badge]: https://coveralls.io/repos/github/senecajs/seneca-apikey/badge.svg?branch=master
 [coveralls-url]: https://coveralls.io/github/senecajs/seneca-apikey?branch=master
 [codeclimate-badge]: https://api.codeclimate.com/v1/badges/79f285a2bfb61305af0f/maintainability
 [codeclimate-url]: https://codeclimate.com/github/senecajs/seneca-apikey/maintainability
 [npm-badge]: https://img.shields.io/npm/v/@seneca/apikey.svg
 [npm-url]: https://npmjs.com/package/@seneca/apikey
-[david-badge]: https://david-dm.org/senecajs/seneca-apikey.svg
-[david-url]: https://david-dm.org/senecajs/seneca-apikey
-[gitter-badge]: https://badges.gitter.im/Join%20Chat.svg
-[gitter-url]: https://gitter.im/senecajs/seneca
 [senecajs org]: https://github.com/senecajs/

--- a/README.md
+++ b/README.md
@@ -15,26 +15,24 @@
 
 ## Install
 
-```sh
+```
 npm install seneca
 npm install seneca-promisify // dependency
 npm install seneca-entity // dependency
 npm install @seneca/user // dependency
 npm install @seneca/apikey
-```js
-
+```
 ## Quick Example
 
 Register an apikey and then create an automatic login for testing.
 
-```js
+```
 const Seneca = require('seneca')
 
 var seneca = Seneca().use('promisify').use('entity').use('apikey')
 
 // TODO: complete quick example
-```js
-
+```
 ## More Examples
 
 Because Seneca treats messages as first-class citizens, 90% of unit
@@ -58,12 +56,10 @@ detailed usage examples:
 
 Set plugin options when loading with:
 
-```js
-
+```
 seneca.use('apikey', { name: value, ... })
 
-```js
-
+```
 <small>Note: <code>foo.bar</code> in the list above means
 <code>{ foo: { bar: ... } }</code></small>
 
@@ -93,13 +89,12 @@ Generate a new API key.
 
 ##### Replies With
 
-```json
+```
 {
   ok: '`true` if successful',
   key: 'key string'
 }
-```js
-
+```
 ---
 
 #### &laquo; `sys:apikey,verify:key` &raquo;
@@ -114,13 +109,12 @@ Verify an API key.
 
 ##### Replies With
 
-```json
+```
 {
   ok: '`true` if verified',
   why: 'explanation code'
 }
-```js
-
+```
 ---
 
 <!--END:action-desc-->


### PR DESCRIPTION
## What changed
- Renamed default branch `master` → `main`
- Added `CODE_OF_CONDUCT.md` v2.1
- Restructured `README.md` with exactly 9 required H1/H2 headings
- Added Voxgig sponsor banner
- Scoped package name
- Added `package-lock.json` to `.gitignore`
- Added `build.yml` GitHub Actions workflow
- Added npm, build and Snyk badges

## Fixes
- `check_default`, `version_codeconduct`, `readme_headings`, `content_readme`, `scoped_package`, `content_gitignore`
